### PR TITLE
feat(report): update gitlab template to populate operating_system value

### DIFF
--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -29,9 +29,9 @@
   {{- range . }}
   {{- $target := .Target }}
     {{- $image := $target | regexFind "[^\\s]+" }}
-    {{- $os := "Unknown" }}
-    {{- if contains "(" $target -}}
-      {{- $os = regexReplaceAll ".+\\((.+)\\)" $target "${1}" }}
+    {{- $os := $target | splitList "(" | last | trimSuffix ")" }}
+    {{- if eq $os $target -}}
+      {{- $os = "Unknown" -}}
     {{- end }}
     {{- range .Vulnerabilities -}}
     {{- if $t_first -}}

--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -29,6 +29,7 @@
   {{- range . }}
   {{- $target := .Target }}
     {{- $image := $target | regexFind "[^\\s]+" }}
+    {{- $os := regexReplaceAll ".+\\((.+)\\)" $target "${1}" }}
     {{- range .Vulnerabilities -}}
     {{- if $t_first -}}
       {{- $t_first = false -}}
@@ -65,7 +66,7 @@
           "version": "{{ .InstalledVersion }}"
         },
         {{- /* TODO: No mapping available - https://github.com/aquasecurity/trivy/issues/332 */}}
-        "operating_system": "Unknown",
+        "operating_system": "{{ $os }}",
         "image": "{{ $image }}"
       },
       "identifiers": [

--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -24,15 +24,18 @@
     "status": "success",
     "type": "container_scanning"
   },
+  {{- $image := "Unknown" -}}
+  {{- $os := "Unknown" -}}
+  {{- range . }}
+    {{- if eq .Class "os-pkgs" -}}
+      {{- $target := .Target }}
+        {{- $image = $target | regexFind "[^\\s]+" }}
+        {{- $os = $target | splitList "(" | last | trimSuffix ")" }}
+    {{- end }}
+  {{- end }}
   "vulnerabilities": [
   {{- $t_first := true }}
   {{- range . }}
-  {{- $target := .Target }}
-    {{- $image := $target | regexFind "[^\\s]+" }}
-    {{- $os := $target | splitList "(" | last | trimSuffix ")" }}
-    {{- if eq $os $target -}}
-      {{- $os = "Unknown" -}}
-    {{- end }}
     {{- range .Vulnerabilities -}}
     {{- if $t_first -}}
       {{- $t_first = false -}}

--- a/contrib/gitlab.tpl
+++ b/contrib/gitlab.tpl
@@ -29,7 +29,10 @@
   {{- range . }}
   {{- $target := .Target }}
     {{- $image := $target | regexFind "[^\\s]+" }}
-    {{- $os := regexReplaceAll ".+\\((.+)\\)" $target "${1}" }}
+    {{- $os := "Unknown" }}
+    {{- if contains "(" $target -}}
+      {{- $os = regexReplaceAll ".+\\((.+)\\)" $target "${1}" }}
+    {{- end }}
     {{- range .Vulnerabilities -}}
     {{- if $t_first -}}
       {{- $t_first = false -}}

--- a/integration/client_server_test.go
+++ b/integration/client_server_test.go
@@ -324,6 +324,17 @@ func TestClientServerWithFormat(t *testing.T) {
 			golden: "testdata/alpine-310.gitlab.golden",
 		},
 		{
+			name: "scan package-lock.json with gitlab template (Unknown os and image)",
+			args: csArgs{
+				Command:         "fs",
+				Format:          "template",
+				TemplatePath:    "@../contrib/gitlab.tpl",
+				Target:          "testdata/fixtures/repo/npm/",
+				ListAllPackages: true,
+			},
+			golden: "testdata/npm.gitlab.golden",
+		},
+		{
 			name: "alpine 3.10 with gitlab-codequality template",
 			args: csArgs{
 				Format:       "template",

--- a/integration/testdata/alpine-310.gitlab.golden
+++ b/integration/testdata/alpine-310.gitlab.golden
@@ -37,7 +37,7 @@
           },
           "version": "1.1.1c-r0"
         },
-        "operating_system": "Unknown",
+        "operating_system": "alpine 3.10.2",
         "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
@@ -104,7 +104,7 @@
           },
           "version": "1.1.1c-r0"
         },
-        "operating_system": "Unknown",
+        "operating_system": "alpine 3.10.2",
         "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
@@ -191,7 +191,7 @@
           },
           "version": "1.1.1c-r0"
         },
-        "operating_system": "Unknown",
+        "operating_system": "alpine 3.10.2",
         "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [
@@ -258,7 +258,7 @@
           },
           "version": "1.1.1c-r0"
         },
-        "operating_system": "Unknown",
+        "operating_system": "alpine 3.10.2",
         "image": "testdata/fixtures/images/alpine-310.tar.gz"
       },
       "identifiers": [

--- a/integration/testdata/npm.gitlab.golden
+++ b/integration/testdata/npm.gitlab.golden
@@ -1,0 +1,214 @@
+{
+  "version": "15.0.7",
+  "scan": {
+    "analyzer": {
+      "id": "trivy",
+      "name": "Trivy",
+      "vendor": {
+        "name": "Aqua Security"
+      },
+      "version": "dev"
+    },
+    "end_time": "2021-08-25T12:20:30",
+    "scanner": {
+      "id": "trivy",
+      "name": "Trivy",
+      "url": "https://github.com/aquasecurity/trivy/",
+      "vendor": {
+        "name": "Aqua Security"
+      },
+      "version": "dev"
+    },
+    "start_time": "2021-08-25T12:20:30",
+    "status": "success",
+    "type": "container_scanning"
+  },
+  "vulnerabilities": [
+    {
+      "id": "CVE-2019-11358",
+      "name": "jquery: Prototype pollution in object's prototype leading to denial of service, remote code execution, or property injection",
+      "description": "jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution. If an unsanitized source object contained an enumerable __proto__ property, it could extend the native Object.prototype.",
+      "severity": "Medium",
+      "solution": "Upgrade jquery to 3.4.0",
+      "location": {
+        "dependency": {
+          "package": {
+            "name": "jquery"
+          },
+          "version": "3.3.9"
+        },
+        "operating_system": "Unknown",
+        "image": "Unknown"
+      },
+      "identifiers": [
+        {
+          "type": "cve",
+          "name": "CVE-2019-11358",
+          "value": "CVE-2019-11358",
+          "url": "https://avd.aquasec.com/nvd/cve-2019-11358"
+        }
+      ],
+      "links": [{
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-08/msg00006.html"
+        },{
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-08/msg00025.html"
+        },{
+          "url": "http://packetstormsecurity.com/files/152787/dotCMS-5.1.1-Vulnerable-Dependencies.html"
+        },{
+          "url": "http://packetstormsecurity.com/files/153237/RetireJS-CORS-Issue-Script-Execution.html"
+        },{
+          "url": "http://packetstormsecurity.com/files/156743/OctoberCMS-Insecure-Dependencies.html"
+        },{
+          "url": "http://seclists.org/fulldisclosure/2019/May/10"
+        },{
+          "url": "http://seclists.org/fulldisclosure/2019/May/11"
+        },{
+          "url": "http://seclists.org/fulldisclosure/2019/May/13"
+        },{
+          "url": "http://www.openwall.com/lists/oss-security/2019/06/03/2"
+        },{
+          "url": "http://www.securityfocus.com/bid/108023"
+        },{
+          "url": "https://access.redhat.com/errata/RHBA-2019:1570"
+        },{
+          "url": "https://access.redhat.com/errata/RHSA-2019:1456"
+        },{
+          "url": "https://access.redhat.com/errata/RHSA-2019:2587"
+        },{
+          "url": "https://access.redhat.com/errata/RHSA-2019:3023"
+        },{
+          "url": "https://access.redhat.com/errata/RHSA-2019:3024"
+        },{
+          "url": "https://access.redhat.com/security/cve/CVE-2019-11358"
+        },{
+          "url": "https://backdropcms.org/security/backdrop-sa-core-2019-009"
+        },{
+          "url": "https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/"
+        },{
+          "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11358"
+        },{
+          "url": "https://github.com/DanielRuf/snyk-js-jquery-174006?files=1"
+        },{
+          "url": "https://github.com/advisories/GHSA-6c3j-c64m-qhgq"
+        },{
+          "url": "https://github.com/jquery/jquery/commit/753d591aea698e57d6db58c9f722cd0808619b1b"
+        },{
+          "url": "https://github.com/jquery/jquery/pull/4333"
+        },{
+          "url": "https://github.com/rails/jquery-rails/blob/master/CHANGELOG.md#434"
+        },{
+          "url": "https://hackerone.com/reports/454365"
+        },{
+          "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44601"
+        },{
+          "url": "https://linux.oracle.com/cve/CVE-2019-11358.html"
+        },{
+          "url": "https://linux.oracle.com/errata/ELSA-2020-4847.html"
+        },{
+          "url": "https://lists.apache.org/thread.html/08720ef215ee7ab3386c05a1a90a7d1c852bf0706f176a7816bf65fc@%3Ccommits.airflow.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@%3Cdev.drill.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/5928aa293e39d248266472210c50f176cac1535220f2486e6a7fa844@%3Ccommits.airflow.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/6097cdbd6f0a337bedd9bb5cc441b2d525ff002a96531de367e4259f@%3Ccommits.airflow.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/88fb0362fd40e5b605ea8149f63241537b8b6fb5bfa315391fc5cbb7@%3Ccommits.airflow.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@%3Cdev.drill.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/b736d0784cf02f5a30fbb4c5902762a15ad6d47e17e2c5a17b7d6205@%3Ccommits.airflow.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/ba79cf1658741e9f146e4c59b50aee56656ea95d841d358d006c18b6@%3Ccommits.roller.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/bcce5a9c532b386c68dab2f6b3ce8b0cc9b950ec551766e76391caa3@%3Ccommits.nifi.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@%3Cissues.drill.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/r2041a75d3fc09dec55adfd95d598b38d22715303f65c997c054844c9@%3Cissues.flink.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/r2baacab6e0acb5a2092eb46ae04fd6c3e8277b4fd79b1ffb7f3254fa@%3Cissues.flink.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/r38f0d1aa3c923c22977fe7376508f030f22e22c1379fbb155bf29766@%3Cdev.syncope.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/r41b5bfe009c845f67d4f68948cc9419ac2d62e287804aafd72892b08@%3Cissues.flink.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/r7aac081cbddb6baa24b75e74abf0929bf309b176755a53e3ed810355@%3Cdev.flink.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/r7d64895cc4dff84d0becfc572b20c0e4bf9bfa7b10c6f5f73e783734@%3Cdev.storm.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/r7e8ebccb7c022e41295f6fdb7b971209b83702339f872ddd8cf8bf73@%3Cissues.flink.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/rac25da84ecdcd36f6de5ad0d255f4e967209bbbebddb285e231da37d@%3Cissues.flink.apache.org%3E"
+        },{
+          "url": "https://lists.apache.org/thread.html/rca37935d661f4689cb4119f1b3b224413b22be161b678e6e6ce0c69b@%3Ccommits.nifi.apache.org%3E"
+        },{
+          "url": "https://lists.debian.org/debian-lts-announce/2019/05/msg00006.html"
+        },{
+          "url": "https://lists.debian.org/debian-lts-announce/2019/05/msg00029.html"
+        },{
+          "url": "https://lists.debian.org/debian-lts-announce/2020/02/msg00024.html"
+        },{
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4UOAZIFCSZ3ENEFOR5IXX6NFAD3HV7FA/"
+        },{
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/5IABSKTYZ5JUGL735UKGXL5YPRYOPUYI/"
+        },{
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KYH3OAGR2RTCHRA5NOKX2TES7SNQMWGO/"
+        },{
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/QV3PKZC3PQCO3273HAT76PAQZFBEO4KP/"
+        },{
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RLXRX23725JL366CNZGJZ7AQQB7LHQ6F/"
+        },{
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WZW27UCJ5CYFL4KFFFMYMIBNMIU2ALG5/"
+        },{
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-11358"
+        },{
+          "url": "https://seclists.org/bugtraq/2019/Apr/32"
+        },{
+          "url": "https://seclists.org/bugtraq/2019/Jun/12"
+        },{
+          "url": "https://seclists.org/bugtraq/2019/May/18"
+        },{
+          "url": "https://security.netapp.com/advisory/ntap-20190919-0001/"
+        },{
+          "url": "https://snyk.io/vuln/SNYK-JS-JQUERY-174006"
+        },{
+          "url": "https://www.debian.org/security/2019/dsa-4434"
+        },{
+          "url": "https://www.debian.org/security/2019/dsa-4460"
+        },{
+          "url": "https://www.drupal.org/sa-core-2019-006"
+        },{
+          "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+        },{
+          "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
+        },{
+          "url": "https://www.oracle.com/security-alerts/cpuapr2020.html"
+        },{
+          "url": "https://www.oracle.com/security-alerts/cpujan2020.html"
+        },{
+          "url": "https://www.oracle.com/security-alerts/cpujan2021.html"
+        },{
+          "url": "https://www.oracle.com/security-alerts/cpujul2020.html"
+        },{
+          "url": "https://www.oracle.com/security-alerts/cpuoct2020.html"
+        },{
+          "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+        },{
+          "url": "https://www.oracle.com/technetwork/security-advisory/cpujul2019-5072835.html"
+        },{
+          "url": "https://www.oracle.com/technetwork/security-advisory/cpuoct2019-5072832.html"
+        },{
+          "url": "https://www.privacy-wise.com/mitigating-cve-2019-11358-in-old-versions-of-jquery/"
+        },{
+          "url": "https://www.synology.com/security/advisory/Synology_SA_19_19"
+        },{
+          "url": "https://www.tenable.com/security/tns-2019-08"
+        },{
+          "url": "https://www.tenable.com/security/tns-2020-02"
+        }
+      ]
+    }
+  ],
+  "remediations": []
+}


### PR DESCRIPTION
## Description
Update the `gitlab.tpl` container scanning template to populate the `vulnerabilities[].location.operating_system` value from the `Target`. The current template [extracts the `image` from `Target`](https://github.com/aquasecurity/trivy/blob/31aa20ab90d52dd6cbc364fe0ff257b59cf02187/contrib/gitlab.tpl#L31), but the OS is not used and has the value hardcoded as [`"operating_system": "Unknown"`](https://github.com/aquasecurity/trivy/blob/31aa20ab90d52dd6cbc364fe0ff257b59cf02187/contrib/gitlab.tpl#L68). This update extracts the OS from `Target`, if specified (simply checking for `(` in the `Target`), to populate the `operating_system` value (for example `"operating_system": "alpine 3.10.2"`). If not specified, the default of `Unknown` is used.

## Related issues
- Partial fix for #332 (for the GitLab template)

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [x] I've included a "before" and "after" example to the description (if the PR is a user interface change).
